### PR TITLE
Point to correct etcd config file

### DIFF
--- a/fixtures/backup-configuration.json
+++ b/fixtures/backup-configuration.json
@@ -1,7 +1,7 @@
 {
   "concurrentRequests": 50,
   "retries": 5,
-  "etcdConfigPath": "fixtures/etcd-dump.json",
+  "etcdConfigPath": "fixtures/etcd-configuration.json",
   "dumpFilePath": "dump.json",
   "backupStrategy": {
     "keys": ["/keys/all"],


### PR DESCRIPTION
Believe the example fixtures file is pointing to the etcd-dump.json incorrectly. Fix to point to the correct config file.